### PR TITLE
Add support for Fabric

### DIFF
--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '16'
+          java-version: '17' # Fabric requires Fabric 17
           distribution: 'temurin'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17' # Fabric requires Fabric 17
+          java-version: '17' # Fabric requires Java 17
           distribution: 'temurin'
       - name: Build with Gradle
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '17' # Fabric requires Fabric 17
+          java-version: '17' # Fabric requires Java 17
           distribution: 'temurin'
       - name: Test Pull Request
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 16
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '16'
+          java-version: '17' # Fabric requires Fabric 17
           distribution: 'temurin'
       - name: Test Pull Request
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### Build/run paths ###
 build/
 run/
+.run/
 target/
 
 ### Gradle ###

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
     version rootProject.version
     archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
 
-    if (['bukkit', 'bungee', 'velocity', 'plugin', 'fabric'].contains(project.name)) {
+    if (['bukkit', 'bungee', 'velocity', 'plugin'].contains(project.name)) {
         shadowJar {
             destinationDirectory.set(file("$rootDir/target"))
             archiveClassifier.set('')

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.0'
     id 'org.ajoberstar.grgit' version '5.0.0'
-    id 'java'
     id 'maven-publish'
+    id 'java'
 }
 
 group 'net.william278'
@@ -26,6 +26,7 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url 'https://maven.fabricmc.net/' } //Fabric maven is above paper maven to get FabricAPi from it over PaperMC
         maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
         maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
         maven { url 'https://repo.papermc.io/repository/maven-public/' }
@@ -53,7 +54,7 @@ subprojects {
     version rootProject.version
     archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
 
-    if (['bukkit', 'bungee', 'velocity', 'plugin'].contains(project.name)) {
+    if (['bukkit', 'bungee', 'velocity', 'plugin', 'fabric'].contains(project.name)) {
         shadowJar {
             destinationDirectory.set(file("$rootDir/target"))
             archiveClassifier.set('')

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     mappings "net.fabricmc:yarn:1.19.3+build.5:v2"
     modCompileOnly "net.fabricmc:fabric-loader:0.14.17"
     modCompileOnly "net.fabricmc.fabric-api:fabric-api:0.76.0+1.19.3"
-
     modCompileOnly "eu.pb4:placeholder-api:2.0.0-pre.3+1.19.3"
 
     implementation project(path: ':common')

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -9,23 +9,10 @@ repositories {
 dependencies {
     minecraft "com.mojang:minecraft:1.19.3"
     mappings "net.fabricmc:yarn:1.19.3+build.5:v2"
-    modImplementation "net.fabricmc:fabric-loader:0.14.17"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:0.76.0+1.19.3"
+    modCompileOnly "net.fabricmc:fabric-loader:0.14.17"
+    modCompileOnly "net.fabricmc.fabric-api:fabric-api:0.76.0+1.19.3"
 
     modCompileOnly "eu.pb4:placeholder-api:2.0.0-pre.3+1.19.3"
 
     implementation project(path: ':common')
-}
-
-shadowJar {
-    relocate 'org.jetbrains', 'net.william278.papiproxybridge.libraries'
-    relocate 'org.intellij', 'net.william278.papiproxybridge.libraries'
-    relocate 'net.jodah', 'net.william278.papiproxybridge.libraries'
-
-    relocate 'org.bstats', 'net.william278.papiproxybridge.libraries.bstats'
-
-    dependencies {
-        //noinspection GroovyAssignabilityCheck
-        exclude dependency(':slf4j-api')
-    }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'fabric-loom' version '1.1-SNAPSHOT'
+}
+
+repositories {
+    maven { url 'https://maven.nucleoid.xyz' } //PlaceholderAPI
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:1.19.3"
+    mappings "net.fabricmc:yarn:1.19.3+build.5:v2"
+    modImplementation "net.fabricmc:fabric-loader:0.14.17"
+    modImplementation "net.fabricmc.fabric-api:fabric-api:0.76.0+1.19.3"
+
+    modCompileOnly "eu.pb4:placeholder-api:2.0.0-pre.3+1.19.3"
+
+    implementation project(path: ':common')
+}
+
+shadowJar {
+    relocate 'org.jetbrains', 'net.william278.papiproxybridge.libraries'
+    relocate 'org.intellij', 'net.william278.papiproxybridge.libraries'
+    relocate 'net.jodah', 'net.william278.papiproxybridge.libraries'
+
+    relocate 'org.bstats', 'net.william278.papiproxybridge.libraries.bstats'
+
+    dependencies {
+        //noinspection GroovyAssignabilityCheck
+        exclude dependency(':slf4j-api')
+    }
+}

--- a/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
@@ -1,0 +1,67 @@
+package net.william278.papiproxybridge;
+
+import eu.pb4.placeholders.api.PlaceholderContext;
+import eu.pb4.placeholders.api.Placeholders;
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.text.Text;
+import net.william278.papiproxybridge.api.PlaceholderAPI;
+import net.william278.papiproxybridge.events.CustomPayloadCallback;
+import net.william278.papiproxybridge.user.FabricUser;
+import net.william278.papiproxybridge.user.OnlineUser;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+
+public class FabricPAPIProxyBridge implements ModInitializer, PAPIProxyBridge {
+    public static final Logger LOGGER = LoggerFactory.getLogger("FabricPAPIProxyBridge");
+    private static MinecraftServer server;
+
+    @Override
+    public void onInitialize() {
+        PlaceholderAPI.register(this);
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> FabricPAPIProxyBridge.server = server);
+
+        CustomPayloadCallback.EVENT.register((channel, byteBuf) -> {
+            if (channel.equals(getChannel())) {
+                this.handlePluginMessage(this, channel, byteBuf.getWrittenBytes());
+            }
+        });
+    }
+
+    @Override
+    public Optional<OnlineUser> findPlayer(@NotNull UUID uuid) {
+        return Optional.ofNullable(server.getPlayerManager().getPlayer(uuid)).map(FabricUser::adapt);
+    }
+
+    @Override
+    public Optional<OnlineUser> findPlayer(@NotNull String username) {
+        return Optional.ofNullable(server.getPlayerManager().getPlayer(username)).map(FabricUser::adapt);
+    }
+
+    @Override
+    public CompletableFuture<String> createRequest(@NotNull String text, @NotNull OnlineUser user) {
+        String json = formatPlaceholders((FabricUser) user, Text.of(text)).getString();
+        return CompletableFuture.completedFuture(json);
+    }
+
+    @Override
+    public void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions) {
+        if (exceptions.length > 0) {
+            LOGGER.error(message, exceptions[0]);
+        } else {
+            LOGGER.info(message);
+        }
+    }
+
+    @NotNull
+    public final Text formatPlaceholders(@NotNull FabricUser user, @NotNull Text text) {
+        return Placeholders.parseText(text, PlaceholderContext.of(user.getPlayer()));
+    }
+}

--- a/fabric/src/main/java/net/william278/papiproxybridge/events/CustomPayloadCallback.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/events/CustomPayloadCallback.java
@@ -1,0 +1,18 @@
+package net.william278.papiproxybridge.events;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.network.PacketByteBuf;
+
+@FunctionalInterface
+public interface CustomPayloadCallback {
+    Event<CustomPayloadCallback> EVENT = EventFactory.createArrayBacked(CustomPayloadCallback.class,
+            (listeners) -> (channel, byteBuf) -> {
+                for (CustomPayloadCallback listener : listeners) {
+                    // Invoke all event listeners with the provided player and death message.
+                    listener.invoke(channel, byteBuf);
+                }
+            });
+
+    void invoke(String channel, PacketByteBuf byteBuf);
+}

--- a/fabric/src/main/java/net/william278/papiproxybridge/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,17 @@
+package net.william278.papiproxybridge.mixin;
+
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.william278.papiproxybridge.events.CustomPayloadCallback;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+    @Inject(at = @At("HEAD"), method = "onCustomPayload(Lnet/minecraft/network/packet/c2s/play/CustomPayloadC2SPacket;)V")
+    private void papiProxyBridge$handlePluginMessage(CustomPayloadC2SPacket packet, CallbackInfo ci) {
+        CustomPayloadCallback.EVENT.invoker().invoke(packet.getChannel().toString(), packet.getData());
+    }
+}

--- a/fabric/src/main/java/net/william278/papiproxybridge/user/FabricUser.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/user/FabricUser.java
@@ -1,0 +1,52 @@
+package net.william278.papiproxybridge.user;
+
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
+import net.william278.papiproxybridge.FabricPAPIProxyBridge;
+import net.william278.papiproxybridge.PAPIProxyBridge;
+import org.jetbrains.annotations.NotNull;
+
+public class FabricUser implements OnlineUser {
+
+    private final ServerPlayerEntity player;
+
+    private FabricUser(@NotNull ServerPlayerEntity player) {
+        this.player = player;
+    }
+
+    @NotNull
+    public static FabricUser adapt(@NotNull ServerPlayerEntity player) {
+        return new FabricUser(player);
+    }
+
+    @Override
+    @NotNull
+    public String getUsername() {
+        return player.getName().getString();
+    }
+
+    @Override
+    public void sendPluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull String channel, byte[] message) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeBytes(message);
+        CustomPayloadS2CPacket packet = new CustomPayloadS2CPacket(new Identifier(channel), buf);
+        player.networkHandler.sendPacket(packet);
+    }
+
+    @Override
+    public void handlePluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull Request message) {
+        FabricPAPIProxyBridge bridge = (FabricPAPIProxyBridge) plugin;
+        message.setMessage(bridge.formatPlaceholders(this, Text.of(message.getMessage())).getString());
+        this.sendPluginMessage(plugin, message);
+    }
+
+    @NotNull
+    public PlayerEntity getPlayer() {
+        return player;
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
     ],
     "depends": {
         "fabricloader": ">=0.14.17",
-        "minecraft": "1.19.3",
+        "minecraft": ">=1.19.3",
         "fabric-api": "*",
         "placeholder-api": "*"
     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,32 @@
+{
+    "schemaVersion": 1,
+    "id": "papiproxybridge",
+    "version": "${version}",
+    "name": "PAPIProxyBridge",
+    "description": "A bridge library mod for using PlaceholderAPI on proxy servers",
+    "authors": [
+        "WiIIiam278"
+    ],
+    "contributors": [
+        "Awakened Redstone"
+    ],
+    "contact": {
+        "repo": "https://github.com/WiIIiam278/PAPIProxyBridge"
+    },
+    "license": "Apache-2.0",
+    "environment": "server",
+    "entrypoints": {
+        "main": [
+            "net.william278.papiproxybridge.FabricPAPIProxyBridge"
+        ]
+    },
+    "mixins": [
+        "papiproxybridge.mixins.json"
+    ],
+    "depends": {
+        "fabricloader": ">=0.14.17",
+        "minecraft": "1.19.3",
+        "fabric-api": "*",
+        "placeholder-api": "*"
+    }
+}

--- a/fabric/src/main/resources/papiproxybridge.mixins.json
+++ b/fabric/src/main/resources/papiproxybridge.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "net.william278.papiproxybridge.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [
+    "ServerPlayNetworkHandlerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     implementation project(path: ':bukkit', configuration: 'shadow')
     implementation project(path: ':bungee', configuration: 'shadow')
     implementation project(path: ':velocity', configuration: 'shadow')
-    implementation project(path: ':fabric', configuration: 'shadow')
+    runtimeOnly project(path: ':fabric')
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -2,4 +2,5 @@ dependencies {
     implementation project(path: ':bukkit', configuration: 'shadow')
     implementation project(path: ':bungee', configuration: 'shadow')
     implementation project(path: ':velocity', configuration: 'shadow')
+    implementation project(path: ':fabric', configuration: 'shadow')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,9 @@
 pluginManagement {
     repositories {
+        maven {
+            name = 'Fabric'
+            url = 'https://maven.fabricmc.net/'
+        }
         gradlePluginPortal()
     }
 }
@@ -12,3 +16,4 @@ include 'proxy'
 include 'bungee'
 include 'velocity'
 include 'plugin'
+include 'fabric'


### PR DESCRIPTION
- [x] Tested placeholders
- [x] Tested in production
- [x] Tested the all in one JAR

This pull request adds support for Patbox's PlaceholderAPI on Fabric servers
Quit support is **unknown**

The mod doesn't include the placeholder API, it depends on the server having a mod that does, if used without another mod that uses it the server won't load due to missing dependency

The mod is server only, it is unsupported on clients