### PR TITLE
Add API method for fetching list of servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ repositories {
 Then add the dependency:
 ```groovy
 dependencies {
-    implementation 'net.william278:papiproxybridge:1.2.1'
-}
+    implementation 'net.william278:papiproxybridge:1.3
 ```
 
 </details>

--- a/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
+++ b/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
@@ -29,6 +29,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -63,6 +64,12 @@ public class BukkitPAPIProxyBridge extends JavaPlugin implements PAPIProxyBridge
         // Unregister the plugin message channel
         getServer().getMessenger().unregisterOutgoingPluginChannel(this);
         getServer().getMessenger().unregisterIncomingPluginChannel(this);
+    }
+
+    @Override
+    @NotNull
+    public List<BukkitUser> getOnlineUsers() {
+        return getServer().getOnlinePlayers().stream().map(BukkitUser::adapt).toList();
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
+++ b/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
@@ -89,7 +89,7 @@ public class BukkitPAPIProxyBridge extends JavaPlugin implements PAPIProxyBridge
 
     @Override
     public CompletableFuture<List<String>> findServers() {
-        throw new UnsupportedOperationException("Cannot fetch the list of servers from a backend Fabric server.");
+        throw new UnsupportedOperationException("Cannot fetch the list of servers from a backend Bukkit server.");
     }
 
     @Override

--- a/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
+++ b/bukkit/src/main/java/net/william278/papiproxybridge/BukkitPAPIProxyBridge.java
@@ -88,6 +88,11 @@ public class BukkitPAPIProxyBridge extends JavaPlugin implements PAPIProxyBridge
     }
 
     @Override
+    public CompletableFuture<List<String>> findServers() {
+        throw new UnsupportedOperationException("Cannot fetch the list of servers from a backend Fabric server.");
+    }
+
+    @Override
     public void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions) {
         if (exceptions.length > 0) {
             getLogger().log(level, message, exceptions[0]);

--- a/bukkit/src/main/java/net/william278/papiproxybridge/papi/Formatter.java
+++ b/bukkit/src/main/java/net/william278/papiproxybridge/papi/Formatter.java
@@ -20,6 +20,7 @@
 package net.william278.papiproxybridge.papi;
 
 import me.clip.placeholderapi.PlaceholderAPI;
+import net.william278.papiproxybridge.PAPIProxyBridge;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -30,6 +31,7 @@ public class Formatter {
 
     @NotNull
     public final String formatPlaceholders(@NotNull UUID formatFor, @NotNull Player requester, @NotNull String text) {
+        text = text.replaceAll(PAPIProxyBridge.HANDSHAKE_PLACEHOLDER, PAPIProxyBridge.HANDSHAKE_RESPONSE);
         return PlaceholderAPI.setPlaceholders(
                 requester.getUniqueId().equals(formatFor) ? requester : Bukkit.getOfflinePlayer(formatFor),
                 text

--- a/bungee/src/main/java/net/william278/papiproxybridge/BungeePAPIProxyBridge.java
+++ b/bungee/src/main/java/net/william278/papiproxybridge/BungeePAPIProxyBridge.java
@@ -29,10 +29,7 @@ import net.william278.papiproxybridge.user.OnlineUser;
 import org.bstats.bungeecord.Metrics;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -75,6 +72,12 @@ public class BungeePAPIProxyBridge extends Plugin implements ProxyPAPIProxyBridg
     @NotNull
     public Map<UUID, CompletableFuture<String>> getRequests() {
         return requests;
+    }
+
+    @Override
+    @NotNull
+    public List<BungeeUser> getOnlineUsers() {
+        return getProxy().getPlayers().stream().map(BungeeUser::adapt).toList();
     }
 
     @Override

--- a/bungee/src/main/java/net/william278/papiproxybridge/user/BungeeUser.java
+++ b/bungee/src/main/java/net/william278/papiproxybridge/user/BungeeUser.java
@@ -54,4 +54,10 @@ public class BungeeUser implements ProxyUser {
     public void sendPluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull String channel, byte[] message) {
         player.getServer().getInfo().sendData(channel, message);
     }
+
+    @Override
+    @NotNull
+    public String getServerName() {
+        return player.getServer().getInfo().getName();
+    }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation 'net.jodah:expiringmap:0.5.10'
 
-    compileOnly 'com.google.guava:guava:31.1-jre'
+    compileOnly 'com.google.guava:guava:32.1.1-jre'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }
 

--- a/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
+++ b/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
@@ -27,12 +27,16 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public interface PAPIProxyBridge {
+
+    String HANDSHAKE_PLACEHOLDER = "%papiproxybridge_handshake%";
+    String HANDSHAKE_RESPONSE = "confirmed";
 
     @NotNull
     default String getChannel() {
@@ -48,6 +52,9 @@ public interface PAPIProxyBridge {
     default String getChannelKey() {
         return "format";
     }
+
+    @NotNull
+    List<? extends OnlineUser> getOnlineUsers();
 
     Optional<OnlineUser> findPlayer(@NotNull UUID uuid);
 
@@ -78,6 +85,8 @@ public interface PAPIProxyBridge {
     }
 
     CompletableFuture<String> createRequest(@NotNull String text, @NotNull OnlineUser requester, @NotNull UUID formatFor);
+
+    CompletableFuture<List<String>> findServers();
 
     void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions);
 

--- a/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
+++ b/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
@@ -60,7 +60,6 @@ public interface PAPIProxyBridge {
 
     Optional<OnlineUser> findPlayer(@NotNull String username);
 
-    @SuppressWarnings("UnstableApiUsage")
     default void handlePluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull String channel, byte[] message) {
         if (!channel.equals(plugin.getChannel())) {
             return;

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -162,6 +163,18 @@ public final class PlaceholderAPI {
         return plugin.findPlayer(player)
                 .map(requester -> formatPlaceholders(text, requester, player))
                 .orElse(CompletableFuture.completedFuture(text));
+    }
+
+    /**
+     * Fetch the list of backend servers with PAPIProxyBridge installed
+     *
+     * @return A future that will supply the list of backend servers
+     * @throws UnsupportedOperationException If this method is called from a backend (Bukkit, Fabric) server
+     * @apiNote This method can only be used from the proxy; it will throw an exception if called from a backend server
+     * @since 1.3
+     */
+    public CompletableFuture<List<String>> findServers() throws UnsupportedOperationException {
+        return plugin.findServers();
     }
 
     /**

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -22,6 +22,7 @@ package net.william278.papiproxybridge.api;
 import net.jodah.expiringmap.ExpiringMap;
 import net.william278.papiproxybridge.PAPIProxyBridge;
 import net.william278.papiproxybridge.user.OnlineUser;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -61,6 +62,7 @@ public final class PlaceholderAPI {
      *
      * @param plugin The plugin to register
      */
+    @ApiStatus.Internal
     private PlaceholderAPI(@NotNull PAPIProxyBridge plugin) {
         this.plugin = plugin;
         this.cache = new HashMap<>();
@@ -85,6 +87,7 @@ public final class PlaceholderAPI {
      *
      * @param plugin The plugin to register
      */
+    @ApiStatus.Internal
     public static void register(@NotNull PAPIProxyBridge plugin) {
         instance = new PlaceholderAPI(plugin);
     }

--- a/common/src/main/java/net/william278/papiproxybridge/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/papiproxybridge/user/OnlineUser.java
@@ -40,7 +40,6 @@ public interface OnlineUser {
 
     void sendPluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull String channel, byte[] message);
 
-    @SuppressWarnings("UnstableApiUsage")
     default void sendPluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull Request request) {
         final ByteArrayDataOutput messageWriter = ByteStreams.newDataOutput();
         messageWriter.writeUTF(getUsername()); // Username

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.3-SNAPSHOT'
 }
 
 repositories {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     mappings "net.fabricmc:yarn:$fabric_yarn_mappings:v2"
     modCompileOnly "net.fabricmc:fabric-loader:$fabric_loader_version"
     modCompileOnly "net.fabricmc.fabric-api:fabric-api:$fabric_api_version"
-    modCompileOnly "eu.pb4:placeholder-api:2.1.1+1.20"
+    modCompileOnly "eu.pb4:placeholder-api:2.1.2+1.20.1"
 
     implementation project(path: ':common')
 }

--- a/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
@@ -78,6 +78,11 @@ public class FabricPAPIProxyBridge implements ModInitializer, PAPIProxyBridge {
     }
 
     @Override
+    public CompletableFuture<List<String>> findServers() {
+        throw new UnsupportedOperationException("Cannot fetch the list of servers from a backend Fabric server.");
+    }
+
+    @Override
     public void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions) {
         if (exceptions.length > 0) {
             LOGGER.error(message, exceptions[0]);

--- a/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/FabricPAPIProxyBridge.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -55,6 +56,12 @@ public class FabricPAPIProxyBridge implements ModInitializer, PAPIProxyBridge {
     }
 
     @Override
+    @NotNull
+    public List<? extends OnlineUser> getOnlineUsers() {
+        return server.getPlayerManager().getPlayerList().stream().map(FabricUser::adapt).toList();
+    }
+
+    @Override
     public Optional<OnlineUser> findPlayer(@NotNull UUID uuid) {
         return Optional.ofNullable(server.getPlayerManager().getPlayer(uuid)).map(FabricUser::adapt);
     }
@@ -66,7 +73,7 @@ public class FabricPAPIProxyBridge implements ModInitializer, PAPIProxyBridge {
 
     @Override
     public CompletableFuture<String> createRequest(@NotNull String text, @NotNull OnlineUser requester, @NotNull UUID formatFor) {
-        String json = formatPlaceholders(formatFor, (FabricUser) requester, Text.of(text)).getString();
+        String json = formatPlaceholders(formatFor, (FabricUser) requester, text).getString();
         return CompletableFuture.completedFuture(json);
     }
 
@@ -80,8 +87,9 @@ public class FabricPAPIProxyBridge implements ModInitializer, PAPIProxyBridge {
     }
 
     @NotNull
-    public final Text formatPlaceholders(@NotNull UUID formatFor, @NotNull FabricUser requester, @NotNull Text text) {
-        return Placeholders.parseText(text, PlaceholderContext.of(
+    public final Text formatPlaceholders(@NotNull UUID formatFor, @NotNull FabricUser requester, @NotNull String text) {
+        text = text.replaceAll(HANDSHAKE_PLACEHOLDER, HANDSHAKE_RESPONSE);
+        return Placeholders.parseText(Text.of(text), PlaceholderContext.of(
                 ((FabricUser) findPlayer(formatFor).orElse(requester)).getPlayer())
         );
     }

--- a/fabric/src/main/java/net/william278/papiproxybridge/user/FabricUser.java
+++ b/fabric/src/main/java/net/william278/papiproxybridge/user/FabricUser.java
@@ -24,7 +24,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.william278.papiproxybridge.FabricPAPIProxyBridge;
 import net.william278.papiproxybridge.PAPIProxyBridge;
@@ -71,7 +70,7 @@ public class FabricUser implements OnlineUser {
         message.setMessage(bridge.formatPlaceholders(
                 message.getFormatFor(),
                 this,
-                Text.of(message.getMessage())
+                message.getMessage()
         ).getString());
         this.sendPluginMessage(plugin, message);
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ javaVersion=16
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 
-plugin_version=1.2.2
+plugin_version=1.3
 plugin_archive=papiproxybridge
 plugin_description=A bridge library plugin for using PlaceholderAPI on proxy servers
 

--- a/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
@@ -54,7 +54,7 @@ public interface ProxyPAPIProxyBridge extends PAPIProxyBridge {
         final Map<String, CompletableFuture<Boolean>> serverMap = getOnlineUsers().stream()
                 .filter(user -> user instanceof ProxyUser)
                 .map(user -> (ProxyUser) user)
-                .collect(Collectors.toMap(
+                .collect(Collectors.toConcurrentMap(
                         ProxyUser::getServerName,
                         user -> createRequest(HANDSHAKE_PLACEHOLDER, user, user.getUniqueId())
                                 .thenApply(message -> message.equals(HANDSHAKE_RESPONSE))

--- a/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
@@ -20,13 +20,17 @@
 package net.william278.papiproxybridge;
 
 import net.william278.papiproxybridge.user.OnlineUser;
+import net.william278.papiproxybridge.user.ProxyUser;
 import net.william278.papiproxybridge.user.Request;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public interface ProxyPAPIProxyBridge extends PAPIProxyBridge {
 
@@ -42,6 +46,29 @@ public interface ProxyPAPIProxyBridge extends PAPIProxyBridge {
             return text;
         });
         requester.sendPluginMessage(this, request);
+        return future;
+    }
+
+    default CompletableFuture<List<String>> findServers() {
+        final CompletableFuture<List<String>> future = new CompletableFuture<>();
+        final Map<String, CompletableFuture<Boolean>> serverMap = getOnlineUsers().stream()
+                .filter(user -> user instanceof ProxyUser)
+                .map(user -> (ProxyUser) user)
+                .collect(Collectors.toMap(
+                        ProxyUser::getServerName,
+                        user -> createRequest(HANDSHAKE_PLACEHOLDER, user, user.getUniqueId())
+                                .thenApply(message -> message.equals(HANDSHAKE_RESPONSE))
+                ));
+
+        CompletableFuture.allOf(serverMap.values().toArray(new CompletableFuture[0]))
+                .thenRun(() -> {
+                    final Set<String> servers = serverMap.entrySet().stream()
+                            .filter(entry -> entry.getValue().getNow(false))
+                            .map(Map.Entry::getKey)
+                            .collect(Collectors.toSet());
+                    future.complete(List.copyOf(servers));
+                });
+
         return future;
     }
 

--- a/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
@@ -23,15 +23,14 @@ import net.william278.papiproxybridge.PAPIProxyBridge;
 import net.william278.papiproxybridge.ProxyPAPIProxyBridge;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.CompletableFuture;
-
 public interface ProxyUser extends OnlineUser {
 
     @Override
     default void handlePluginMessage(@NotNull PAPIProxyBridge plugin, @NotNull Request message) {
-        ((ProxyPAPIProxyBridge) plugin).getRequests()
-                .getOrDefault(message.getUuid(), new CompletableFuture<>())
-                .complete(message.getMessage());
+        ((ProxyPAPIProxyBridge) plugin).getRequests().computeIfPresent(message.getUuid(), (uuid, future) -> {
+            future.complete(message.getMessage());
+            return null;
+        });
     }
 
     @NotNull

--- a/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
@@ -34,4 +34,7 @@ public interface ProxyUser extends OnlineUser {
                 .complete(message.getMessage());
     }
 
+    @NotNull
+    String getServerName();
+
 }

--- a/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
+++ b/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
@@ -34,10 +34,7 @@ import org.bstats.velocity.Metrics;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
@@ -91,6 +88,12 @@ public class VelocityPAPIProxyBridge implements ProxyPAPIProxyBridge {
     @NotNull
     public Map<UUID, CompletableFuture<String>> getRequests() {
         return requests;
+    }
+
+    @Override
+    @NotNull
+    public List<VelocityUser> getOnlineUsers() {
+        return server.getAllPlayers().stream().map(VelocityUser::adapt).toList();
     }
 
     @Override

--- a/velocity/src/main/java/net/william278/papiproxybridge/user/VelocityUser.java
+++ b/velocity/src/main/java/net/william278/papiproxybridge/user/VelocityUser.java
@@ -57,8 +57,17 @@ public class VelocityUser implements ProxyUser {
         player.getCurrentServer().ifPresent(server -> {
             if (!server.sendPluginMessage(((VelocityPAPIProxyBridge) plugin).getChannelIdentifier(), message)) {
                 plugin.log(Level.SEVERE, "Failed to send plugin message to " + server.getServerInfo().getName()
-                                         + " for player " + player.getUsername() + " on channel " + ((VelocityPAPIProxyBridge) plugin).getChannelIdentifier().getId());
+                                         + " for player " + player.getUsername() + " on channel "
+                                         + ((VelocityPAPIProxyBridge) plugin).getChannelIdentifier().getId());
             }
         });
+    }
+
+    @Override
+    @NotNull
+    public String getServerName() {
+        return player.getCurrentServer()
+                .map(serverConnection -> serverConnection.getServerInfo().getName())
+                .orElse("unknown");
     }
 }


### PR DESCRIPTION
Closes #43

Adds a method, `#findServers()`, to the `PlaceholderAPI` class that returns a `Future<List<String>>` containing the list of server IDs where PAPIProxyBridge is installed and a player online (in other words, the servers that can currently actively be queried to process placeholder requests). This method is only supported from the Proxy.

This works by dispatching a request to each distinct server with a player online, and observing if a special internal `%papiproxybridge_handshake%` placeholder was formatted; those that returned having completed the handshake are returned in a `List`.

Paging @Andre601 as the requester &mdash; free to test (something I have not done fully myself yet) & review.