### PR TITLE
feat: add instance creator and handle velocity event

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The method returns a [CompletableFuture](https://www.baeldung.com/java-completab
 
 ```java
 // Format a string with placeholders
-final PlaceholderAPI api = PlaceholderAPI.getInstance();
+final PlaceholderAPI api = PlaceholderAPI.createInstance();
 final UUID player = player.getUniqueId();
 api.formatPlaceholders("Hello %player_name%!", player).thenAccept(formatted -> {
     player.sendMessage(formatted);

--- a/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
+++ b/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
@@ -21,6 +21,7 @@ package net.william278.papiproxybridge;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
+import net.william278.papiproxybridge.api.PlaceholderAPI;
 import net.william278.papiproxybridge.user.OnlineUser;
 import net.william278.papiproxybridge.user.Request;
 import org.jetbrains.annotations.NotNull;
@@ -89,4 +90,7 @@ public interface PAPIProxyBridge {
 
     void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions);
 
+    default PlaceholderAPI createInstance() {
+        return PlaceholderAPI.create(this);
+    }
 }

--- a/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
+++ b/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
@@ -90,7 +90,4 @@ public interface PAPIProxyBridge {
 
     void log(@NotNull Level level, @NotNull String message, @NotNull Throwable... exceptions);
 
-    default PlaceholderAPI createInstance() {
-        return PlaceholderAPI.create(this);
-    }
 }

--- a/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
+++ b/common/src/main/java/net/william278/papiproxybridge/PAPIProxyBridge.java
@@ -21,7 +21,6 @@ package net.william278.papiproxybridge;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteStreams;
-import net.william278.papiproxybridge.api.PlaceholderAPI;
 import net.william278.papiproxybridge.user.OnlineUser;
 import net.william278.papiproxybridge.user.Request;
 import org.jetbrains.annotations.NotNull;

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -67,7 +67,7 @@ public final class PlaceholderAPI {
     }
 
     /**
-     * Get the instance of the API. This is the entry point for the API
+     * Get the instance of the API. This is an entry point for the API. Shares expiration settings with all other plugins using this instance. Prefer {@link #createInstance()} for unique instance customisation.
      *
      * @return The instance of the API
      * @since 1.0
@@ -81,6 +81,16 @@ public final class PlaceholderAPI {
     }
 
     /**
+     * Create a new instance of PlaceholderAPI allowing unique customisation of caching mechanisms
+     *
+     * @return PlaceholderAPI instance that can be used to format text
+     * @since 1.3
+     */
+    public static PlaceholderAPI createInstance() {
+        return new PlaceholderAPI();
+    }
+
+    /**
      * <b>Internal only</b> - Register the plugin with the API
      *
      * @param plugin The plugin to register
@@ -89,14 +99,6 @@ public final class PlaceholderAPI {
     public static void register(@NotNull PAPIProxyBridge plugin) {
         PlaceholderAPI.plugin = plugin;
         instance = new PlaceholderAPI();
-    }
-
-    /**
-     * Create a new instance of PlaceholderAPI allowing unique customisation of caching mechanisms
-     * @return PlaceholderAPI instance that can be used to format text
-     */
-    public static PlaceholderAPI createInstance() {
-        return new PlaceholderAPI();
     }
 
     /**

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -51,8 +51,6 @@ import java.util.concurrent.TimeUnit;
  */
 @SuppressWarnings("unused")
 public final class PlaceholderAPI {
-
-    private static PlaceholderAPI instance;
     private static PAPIProxyBridge plugin;
     private final Map<UUID, ExpiringMap<String, String>> cache;
     private long requestTimeout = 400;
@@ -98,7 +96,6 @@ public final class PlaceholderAPI {
     @ApiStatus.Internal
     public static void register(@NotNull PAPIProxyBridge plugin) {
         PlaceholderAPI.plugin = plugin;
-        instance = new PlaceholderAPI();
     }
 
     /**

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -53,19 +53,16 @@ import java.util.concurrent.TimeUnit;
 public final class PlaceholderAPI {
 
     private static PlaceholderAPI instance;
-    private final PAPIProxyBridge plugin;
+    private static PAPIProxyBridge plugin;
     private final Map<UUID, ExpiringMap<String, String>> cache;
     private long requestTimeout = 400;
     private long cacheExpiry = 30000;
 
     /**
      * <b>Internal only</b> - Create a new instance of the API
-     *
-     * @param plugin The plugin to register
      */
     @ApiStatus.Internal
-    private PlaceholderAPI(@NotNull PAPIProxyBridge plugin) {
-        this.plugin = plugin;
+    private PlaceholderAPI() {
         this.cache = new HashMap<>();
     }
 
@@ -90,7 +87,16 @@ public final class PlaceholderAPI {
      */
     @ApiStatus.Internal
     public static void register(@NotNull PAPIProxyBridge plugin) {
-        instance = new PlaceholderAPI(plugin);
+        PlaceholderAPI.plugin = plugin;
+        instance = new PlaceholderAPI();
+    }
+
+    /**
+     * Create a new instance of PlaceholderAPI allowing unique customisation of caching mechanisms
+     * @return PlaceholderAPI instance that can be used to format text
+     */
+    public static PlaceholderAPI createInstance() {
+        return new PlaceholderAPI();
     }
 
     /**

--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -69,15 +69,15 @@ public final class PlaceholderAPI {
     /**
      * Get the instance of the API. This is an entry point for the API. Shares expiration settings with all other plugins using this instance. Prefer {@link #createInstance()} for unique instance customisation.
      *
-     * @return The instance of the API
+     * @deprecated Use {@link #createInstance()}
+     * @apiNote From version 1.3 getInstance will return a new instance of the PlaceholderAPI rather than a singleton
+     * @return An instance of the API
      * @since 1.0
      */
+    @Deprecated
     @NotNull
     public static PlaceholderAPI getInstance() {
-        if (instance == null) {
-            throw new IllegalStateException("ProxyPlaceholderApi is not initialized");
-        }
-        return instance;
+        return createInstance();
     }
 
     /**

--- a/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
+++ b/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
@@ -73,6 +73,7 @@ public class VelocityPAPIProxyBridge implements ProxyPAPIProxyBridge {
     @Subscribe
     public void onPluginMessageReceived(@NotNull PluginMessageEvent event) {
         handlePluginMessage(this, event.getIdentifier().getId(), event.getData());
+        event.setResult(PluginMessageEvent.ForwardResult.handled());
     }
 
     @Override


### PR DESCRIPTION
Adds the ability to create instances of PlaceholderAPI to manage caching separately

Also fixes an issue where the Velocity event for the placeholder was still forwarded to the client