### PR TITLE
Fix #69

### DIFF
--- a/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/ProxyPAPIProxyBridge.java
@@ -43,7 +43,7 @@ public interface ProxyPAPIProxyBridge extends PAPIProxyBridge {
     default CompletableFuture<String> createRequest(@NotNull String text, @NotNull OnlineUser requester, @NotNull UUID formatFor) {
         final Request request = new Request(text, formatFor);
         final CompletableFuture<String> future = new CompletableFuture<>();
-        getRequests().put(request.getUuid(), future);
+        getRequests().putIfAbsent(request.getUuid(), future);
         future.orTimeout(REQUEST_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS).exceptionally(throwable -> {
             getRequests().remove(request.getUuid());
             return text;


### PR DESCRIPTION
Currently, it appears that this has not caused any functional damage, and there have been no further instances of deadlock occurring within a certain period of time. You may consider waiting for a while longer until I can provide you with definite results.

https://github.com/WiIIiam278/PAPIProxyBridge/issues/69