### PR TITLE
Add identifier check to PluginMessageEvent in velocity

### DIFF
--- a/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
+++ b/velocity/src/main/java/net/william278/papiproxybridge/VelocityPAPIProxyBridge.java
@@ -76,6 +76,10 @@ public class VelocityPAPIProxyBridge implements ProxyPAPIProxyBridge {
 
     @Subscribe
     public void onPluginMessageReceived(@NotNull PluginMessageEvent event) {
+        if (!event.getIdentifier().equals(getChannelIdentifier())) {
+            return;
+        }
+
         handlePluginMessage(this, event.getIdentifier().getId(), event.getData());
         event.setResult(PluginMessageEvent.ForwardResult.handled());
     }


### PR DESCRIPTION
Without this check, line below sets all plugin messages as handled and breaks other plugins
```java
event.setResult(PluginMessageEvent.ForwardResult.handled());
```