### PR TITLE
Fix placeholder cache reuse across backend switches

### DIFF
--- a/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
+++ b/common/src/main/java/net/william278/papiproxybridge/api/PlaceholderAPI.java
@@ -121,7 +121,7 @@ public final class PlaceholderAPI {
         });
     }
 
-    private record CacheKey(@NotNull UUID requester, @NotNull UUID formatFor) {
+    private record CacheKey(@NotNull UUID requester, @NotNull UUID formatFor, @NotNull String scope) {
 
         private boolean contains(@NotNull UUID player) {
             return requester.equals(player) || formatFor.equals(player);
@@ -168,7 +168,7 @@ public final class PlaceholderAPI {
         if (!requester.isConnected()) {
             return CompletableFuture.completedFuture(text);
         }
-        final CacheKey cacheKey = new CacheKey(requester.getUniqueId(), formatFor);
+        final CacheKey cacheKey = new CacheKey(requester.getUniqueId(), formatFor, requester.getPlaceholderCacheScope());
         if (cacheExpiry > 0 && cache.containsKey(cacheKey) && cache.get(cacheKey).containsKey(text)) {
             return CompletableFuture.completedFuture(cache.get(cacheKey).get(text));
         }
@@ -273,7 +273,7 @@ public final class PlaceholderAPI {
         if (!requester.isConnected()) {
             return CompletableFuture.completedFuture(Component.text(text));
         }
-        final CacheKey cacheKey = new CacheKey(requester.getUniqueId(), formatFor);
+        final CacheKey cacheKey = new CacheKey(requester.getUniqueId(), formatFor, requester.getPlaceholderCacheScope());
         if (cacheExpiry > 0 && componentCache.containsKey(cacheKey) && componentCache.get(cacheKey).containsKey(text)) {
             return CompletableFuture.completedFuture(componentCache.get(cacheKey).get(text));
         }

--- a/common/src/main/java/net/william278/papiproxybridge/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/papiproxybridge/user/OnlineUser.java
@@ -36,6 +36,18 @@ public interface OnlineUser {
     @NotNull
     UUID getUniqueId();
 
+    /**
+     * Returns the runtime context in which placeholder results may be reused.
+     * Implementations should change this value when the same user can resolve
+     * placeholders against a different backend or data source.
+     *
+     * @return the placeholder cache scope
+     */
+    @NotNull
+    default String getPlaceholderCacheScope() {
+        return "";
+    }
+
     default void sendMessage(@NotNull PAPIProxyBridge plugin, @NotNull Request request, boolean wantsJson, boolean isRequest) {
         final ByteArrayDataOutput messageWriter = ByteStreams.newDataOutput();
         final UUID uuid = getUniqueId();

--- a/common/src/test/java/net/william278/papiproxybridge/api/PlaceholderAPITest.java
+++ b/common/src/test/java/net/william278/papiproxybridge/api/PlaceholderAPITest.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
@@ -90,6 +91,30 @@ class PlaceholderAPITest {
     }
 
     @Test
+    void cacheIsIsolatedByBackendServer() {
+        final TestProxyUser proxyUser = new TestProxyUser(UUID.randomUUID(), "lobby");
+        bridge.response = "lobby";
+        assertEquals("lobby", api.formatPlaceholders("%server_name%", proxyUser).join());
+
+        proxyUser.serverName = "survival";
+        bridge.response = "survival";
+        assertEquals("survival", api.formatPlaceholders("%server_name%", proxyUser).join());
+        assertEquals(2, bridge.requests.get());
+    }
+
+    @Test
+    void componentCacheIsIsolatedByBackendServer() {
+        final TestProxyUser proxyUser = new TestProxyUser(UUID.randomUUID(), "lobby");
+        bridge.response = "{\"text\":\"lobby\"}";
+        assertEquals(Component.text("lobby"), api.formatComponentPlaceholders("%server_name%", proxyUser).join());
+
+        proxyUser.serverName = "survival";
+        bridge.response = "{\"text\":\"survival\"}";
+        assertEquals(Component.text("survival"), api.formatComponentPlaceholders("%server_name%", proxyUser).join());
+        assertEquals(2, bridge.requests.get());
+    }
+
+    @Test
     void retriesFailedRequests() {
         api.setRetryTimes(1);
         bridge.failures = 1;
@@ -99,11 +124,23 @@ class PlaceholderAPITest {
         assertEquals(2, bridge.requests.get());
     }
 
+    @Test
+    void retriesTimedOutRequests() throws Exception {
+        api.setRequestTimeout(20);
+        api.setRetryTimes(1);
+        bridge.timeouts = 1;
+        bridge.response = "formatted";
+
+        assertEquals("formatted", api.formatPlaceholders("%name%", requester).get(1, TimeUnit.SECONDS));
+        assertEquals(2, bridge.requests.get());
+    }
+
     private static final class TestBridge implements PAPIProxyBridge {
         private final TestUser user;
         private final AtomicInteger requests = new AtomicInteger();
         private String response;
         private int failures;
+        private int timeouts;
 
         private TestBridge(TestUser user) {
             this.user = user;
@@ -128,6 +165,9 @@ class PlaceholderAPITest {
         public CompletableFuture<String> createRequest(@NotNull String text, @NotNull OnlineUser requester,
                                                        @NotNull UUID formatFor, boolean wantsJson, long requestTimeout) {
             requests.incrementAndGet();
+            if (timeouts-- > 0) {
+                return new CompletableFuture<>();
+            }
             if (failures-- > 0) {
                 return CompletableFuture.failedFuture(new IllegalStateException("failed"));
             }
@@ -176,6 +216,35 @@ class PlaceholderAPITest {
         @Override
         public @NotNull UUID getUniqueId() {
             return uuid;
+        }
+
+        @Override
+        public void handleMessage(@NotNull PAPIProxyBridge plugin, @NotNull Request message, boolean wantsJson) {
+        }
+    }
+
+    private static final class TestProxyUser implements OnlineUser {
+        private final UUID uuid;
+        private String serverName;
+
+        private TestProxyUser(UUID uuid, String serverName) {
+            this.uuid = uuid;
+            this.serverName = serverName;
+        }
+
+        @Override
+        public @NotNull String getUsername() {
+            return "proxy-user";
+        }
+
+        @Override
+        public @NotNull UUID getUniqueId() {
+            return uuid;
+        }
+
+        @Override
+        public @NotNull String getPlaceholderCacheScope() {
+            return serverName;
         }
 
         @Override

--- a/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
+++ b/proxy/src/main/java/net/william278/papiproxybridge/user/ProxyUser.java
@@ -43,4 +43,10 @@ public interface ProxyUser extends OnlineUser {
     @NotNull
     String getServerName();
 
+    @Override
+    @NotNull
+    default String getPlaceholderCacheScope() {
+        return getServerName();
+    }
+
 }


### PR DESCRIPTION
## Summary
- include the requester backend in placeholder cache keys on proxy platforms
- prevent string and component results from one backend being reused after a server switch
- preserve the existing stable cache scope for non-proxy users
- add regression coverage for backend switches and real request timeouts

## Regression evidence
- before the cache-key change, both backend-switch tests returned the cached `lobby` value after moving the requester to `survival`
- after the change, the second request is sent to the new backend and both tests pass

## Verification
- `./gradlew :common:test :proxy:test --rerun-tasks --configure-on-demand --no-daemon --console=plain --max-workers=1`
  - 9 tests, 0 failures/errors/skips
- `./gradlew :bukkit:compileJava :bungee:compileJava :velocity:compileJava --rerun-tasks --configure-on-demand --no-daemon --console=plain --max-workers=1`
- independent review of staged diff `a5225d3fd8f0b26f22394aab99caf0226086e8ba8c4cdf9e5bec09ea6a79ded9`: no security or logic blockers